### PR TITLE
feat: task listにセクション表示機能を追加し、番号表示を削除

### DIFF
--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -34,6 +34,24 @@ func (c *Client) GetProjects(ctx context.Context, syncToken string) (*SyncRespon
 	return c.Sync(ctx, req)
 }
 
+// GetSections はセクションのみを取得する
+func (c *Client) GetSections(ctx context.Context, syncToken string) (*SyncResponse, error) {
+	req := &SyncRequest{
+		SyncToken:     syncToken,
+		ResourceTypes: []string{ResourceSections},
+	}
+	return c.Sync(ctx, req)
+}
+
+// GetAllSections は全セクション情報を取得する
+func (c *Client) GetAllSections(ctx context.Context) ([]Section, error) {
+	resp, err := c.GetSections(ctx, "*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sections: %w", err)
+	}
+	return resp.Sections, nil
+}
+
 // AddItem は新しいタスクを追加する
 func (c *Client) AddItem(ctx context.Context, content, projectID string) (*SyncResponse, error) {
 	cmd := Command{


### PR DESCRIPTION
## Summary
- task listでセクション名を [セクション名] 形式で併記表示
- task listの番号表示を削除（task IDとの混同を防ぐため）
- セクション情報を取得するAPI関数を追加

## Changes
- `GetSections`/`GetAllSections` API関数を追加
- `displayTask`関数でセクション名を併記表示
- `buildSectionsMap`関数でセクション情報をマッピング
- タスクの番号表示を削除してよりコンパクトに

## Test plan
- [ ] セクションがあるタスクで正しく表示されることを確認
- [ ] セクションがないタスクでも正常に表示されることを確認
- [ ] API エラー時の適切なハンドリングを確認
- [ ] 既存の verbose モードが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)