### PR TITLE
refactor: configパッケージからインスタンス生成責務を分離 (#34)

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kyokomi/gotodoist/internal/api"
 	"github.com/kyokomi/gotodoist/internal/config"
+	"github.com/kyokomi/gotodoist/internal/factory"
 	"github.com/kyokomi/gotodoist/internal/repository"
 )
 
@@ -594,7 +595,7 @@ func setupProjectExecution(ctx context.Context) (*projectExecutor, error) {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	repo, err := cfg.NewRepository(verbose)
+	repo, err := factory.NewRepository(cfg, verbose)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Repository: %w", err)
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kyokomi/gotodoist/internal/config"
+	"github.com/kyokomi/gotodoist/internal/factory"
 	"github.com/kyokomi/gotodoist/internal/repository"
 	"github.com/kyokomi/gotodoist/internal/sync"
 )
@@ -191,7 +192,7 @@ func setupSyncExecution(ctx context.Context) (*syncExecutor, error) {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	repo, err := cfg.NewRepository(verbose)
+	repo, err := factory.NewRepository(cfg, verbose)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repository: %w", err)
 	}

--- a/cmd/task.go
+++ b/cmd/task.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kyokomi/gotodoist/internal/api"
 	"github.com/kyokomi/gotodoist/internal/config"
+	"github.com/kyokomi/gotodoist/internal/factory"
 	"github.com/kyokomi/gotodoist/internal/repository"
 )
 
@@ -531,7 +532,7 @@ func setupTaskExecution(ctx context.Context) (*taskExecutor, error) {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	repo, err := cfg.NewRepository(verbose)
+	repo, err := factory.NewRepository(cfg, verbose)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Repository: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/kyokomi/gotodoist/internal/api"
 	"github.com/kyokomi/gotodoist/internal/repository"
 )
 
@@ -93,39 +92,6 @@ func LoadConfig() (*Config, error) {
 	}
 
 	return &config, nil
-}
-
-// NewAPIClient は設定からAPIクライアントを作成する
-func (c *Config) NewAPIClient() (*api.Client, error) {
-	client, err := api.NewClient(c.APIToken)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	if c.BaseURL != "" {
-		if err := client.SetBaseURL(c.BaseURL); err != nil {
-			return nil, fmt.Errorf("failed to set base URL: %w", err)
-		}
-	}
-
-	return client, nil
-}
-
-// NewRepository は設定からRepositoryを作成する
-func (c *Config) NewRepository(verbose bool) (*repository.Repository, error) {
-	// 基本APIクライアントを作成
-	apiClient, err := c.NewAPIClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	// Repositoryを作成
-	localRepository, err := repository.NewRepository(apiClient, c.LocalStorage, verbose)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Repository: %w", err)
-	}
-
-	return localRepository, nil
 }
 
 // GetConfigDir は設定ディレクトリのパスを返す（XDG Base Directory仕様に準拠）

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -129,61 +129,6 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
-func TestConfig_NewAPIClient(t *testing.T) {
-	tests := []struct {
-		name      string
-		token     string
-		baseURL   string
-		wantError bool
-	}{
-		{
-			name:      "valid config",
-			token:     "test-token",
-			baseURL:   "https://api.todoist.com/api/v1",
-			wantError: false,
-		},
-		{
-			name:      "empty token",
-			token:     "",
-			baseURL:   "https://api.todoist.com/api/v1",
-			wantError: true,
-		},
-		{
-			name:      "invalid base URL",
-			token:     "test-token",
-			baseURL:   "ht!tp://invalid-url with spaces",
-			wantError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config := &Config{
-				APIToken: tt.token,
-				BaseURL:  tt.baseURL,
-			}
-
-			client, err := config.NewAPIClient()
-
-			if tt.wantError {
-				if err == nil {
-					t.Error("expected error but got nil")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-				return
-			}
-
-			if client == nil {
-				t.Error("expected client but got nil")
-			}
-		})
-	}
-}
-
 func TestGetConfigDir(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -248,44 +193,6 @@ func TestGetConfigDir(t *testing.T) {
 				t.Errorf("expected config dir %s, got %s", expectedDir, configDir)
 			}
 		})
-	}
-}
-
-func TestConfig_NewAPIClient_WithCustomBaseURL(t *testing.T) {
-	config := &Config{
-		APIToken: "test-token",
-		BaseURL:  "https://custom.api.com",
-	}
-
-	client, err := config.NewAPIClient()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
-
-	if client == nil {
-		t.Error("expected client but got nil")
-		return
-	}
-
-	// BaseURL が正しく設定されているかは、APIクライアント内部の実装詳細なので
-	// ここでは単純にエラーが発生しないことを確認
-}
-
-func TestConfig_NewAPIClient_WithEmptyBaseURL(t *testing.T) {
-	config := &Config{
-		APIToken: "test-token",
-		BaseURL:  "",
-	}
-
-	client, err := config.NewAPIClient()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-		return
-	}
-
-	if client == nil {
-		t.Error("expected client but got nil")
 	}
 }
 

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -1,0 +1,43 @@
+// Package factory provides factory functions for creating various instances.
+package factory
+
+import (
+	"fmt"
+
+	"github.com/kyokomi/gotodoist/internal/api"
+	"github.com/kyokomi/gotodoist/internal/config"
+	"github.com/kyokomi/gotodoist/internal/repository"
+)
+
+// NewAPIClient は設定からAPIクライアントを作成する
+func NewAPIClient(cfg *config.Config) (*api.Client, error) {
+	client, err := api.NewClient(cfg.APIToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	if cfg.BaseURL != "" {
+		if err := client.SetBaseURL(cfg.BaseURL); err != nil {
+			return nil, fmt.Errorf("failed to set base URL: %w", err)
+		}
+	}
+
+	return client, nil
+}
+
+// NewRepository は設定からRepositoryを作成する
+func NewRepository(cfg *config.Config, verbose bool) (*repository.Repository, error) {
+	// 基本APIクライアントを作成
+	apiClient, err := NewAPIClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	// Repositoryを作成
+	localRepository, err := repository.NewRepository(apiClient, cfg.LocalStorage, verbose)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Repository: %w", err)
+	}
+
+	return localRepository, nil
+}

--- a/internal/factory/factory_test.go
+++ b/internal/factory/factory_test.go
@@ -1,0 +1,128 @@
+package factory
+
+import (
+	"testing"
+
+	"github.com/kyokomi/gotodoist/internal/config"
+	"github.com/kyokomi/gotodoist/internal/repository"
+)
+
+func TestNewAPIClient(t *testing.T) {
+	tests := []struct {
+		name      string
+		token     string
+		baseURL   string
+		wantError bool
+	}{
+		{
+			name:      "valid config",
+			token:     "test-token",
+			baseURL:   "https://api.todoist.com/api/v1",
+			wantError: false,
+		},
+		{
+			name:      "empty token",
+			token:     "",
+			baseURL:   "https://api.todoist.com/api/v1",
+			wantError: true,
+		},
+		{
+			name:      "invalid base URL",
+			token:     "test-token",
+			baseURL:   "ht!tp://invalid-url with spaces",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				APIToken: tt.token,
+				BaseURL:  tt.baseURL,
+			}
+
+			client, err := NewAPIClient(cfg)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if client == nil {
+				t.Error("expected client but got nil")
+			}
+		})
+	}
+}
+
+func TestNewAPIClient_WithCustomBaseURL(t *testing.T) {
+	cfg := &config.Config{
+		APIToken: "test-token",
+		BaseURL:  "https://custom.api.com",
+	}
+
+	client, err := NewAPIClient(cfg)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+
+	if client == nil {
+		t.Error("expected client but got nil")
+		return
+	}
+
+	// BaseURL が正しく設定されているかは、APIクライアント内部の実装詳細なので
+	// ここでは単純にエラーが発生しないことを確認
+}
+
+func TestNewAPIClient_WithEmptyBaseURL(t *testing.T) {
+	cfg := &config.Config{
+		APIToken: "test-token",
+		BaseURL:  "",
+	}
+
+	client, err := NewAPIClient(cfg)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+
+	if client == nil {
+		t.Error("expected client but got nil")
+	}
+}
+
+func TestNewRepository(t *testing.T) {
+	cfg := &config.Config{
+		APIToken:     "test-token",
+		BaseURL:      "https://api.todoist.com/api/v1",
+		Language:     "en",
+		LocalStorage: repository.DefaultConfig(),
+	}
+
+	repo, err := NewRepository(cfg, false)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+
+	if repo == nil {
+		t.Error("expected repository but got nil")
+		return
+	}
+
+	// Repositoryが正常に作成されたことを確認
+	defer func() {
+		if closeErr := repo.Close(); closeErr != nil {
+			t.Errorf("failed to close repository: %v", closeErr)
+		}
+	}()
+}


### PR DESCRIPTION
## Summary
- internal/factoryパッケージを作成し、Factory パターンでインスタンス生成を一元管理
- configパッケージから NewAPIClient/NewRepository メソッドを削除し、純粋な設定管理のみに集中
- 単一責任原則に従い、各パッケージの責務を明確に分離

## Changes
- 🆕 `internal/factory` パッケージ作成
- ✅ `NewAPIClient`, `NewRepository` をfactoryに移動
- 🗑️ configパッケージからインスタンス生成メソッドを削除
- 🔧 cmdパッケージで `factory.NewRepository(cfg, verbose)` を使用
- 🧪 テストをfactoryパッケージに移動・追加

## Test plan
- [x] make fmt実行済み
- [x] make lint実行済み（0 issues）  
- [x] make test実行済み（全テスト通過）
- [x] 既存機能の動作確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)