### PR TITLE
feat: Codecovバッジを追加し、カバレッジ計測を改善

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,23 @@ jobs:
     - name: Run tests
       run: go test -v -race ./...
 
-    - name: Upload coverage
+    - name: Generate coverage report
       if: matrix.os == 'ubuntu-latest'
       run: |
         go test -v -race -coverprofile=coverage.out ./...
-        bash <(curl -s https://codecov.io/bash)
+        go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//g' > coverage-percent.txt
+        echo "coverage=$(cat coverage-percent.txt)" >> $GITHUB_OUTPUT
+      id: coverage
+
+    - name: Upload coverage to Codecov
+      if: matrix.os == 'ubuntu-latest' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: codecov/codecov-action@v5
+      with:
+        files: ./coverage.out
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gotodoist
 
 [![CI](https://github.com/kyokomi/gotodoist/actions/workflows/ci.yml/badge.svg)](https://github.com/kyokomi/gotodoist/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/github/kyokomi/gotodoist/graph/badge.svg?token=cGdi7YkLjv)](https://codecov.io/github/kyokomi/gotodoist)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kyokomi/gotodoist)](https://goreportcard.com/report/github.com/kyokomi/gotodoist)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Go Reference](https://pkg.go.dev/badge/github.com/kyokomi/gotodoist.svg)](https://pkg.go.dev/github.com/kyokomi/gotodoist)

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,6 +1,7 @@
 # gotodoist
 
 [![CI](https://github.com/kyokomi/gotodoist/actions/workflows/ci.yml/badge.svg)](https://github.com/kyokomi/gotodoist/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/github/kyokomi/gotodoist/graph/badge.svg?token=cGdi7YkLjv)](https://codecov.io/github/kyokomi/gotodoist)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kyokomi/gotodoist)](https://goreportcard.com/report/github.com/kyokomi/gotodoist)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Go Reference](https://pkg.go.dev/badge/github.com/kyokomi/gotodoist.svg)](https://pkg.go.dev/github.com/kyokomi/gotodoist)


### PR DESCRIPTION
## Summary
- Codecov Action v5への更新
- README（英語・日本語）にカバレッジバッジを追加
- GitHub Actionsでのカバレッジレポート生成処理を改善

## Test plan
- [x] make fmt/lint/test 実行済み
- [ ] CI/CDパイプラインでのカバレッジ計測の動作確認

## Note
Codecovトークンは既にシークレットに設定されているようで、バッジURLも正しいトークンが含まれています。

🤖 Generated with [Claude Code](https://claude.ai/code)