### PR TITLE
refactor: 言語設定機能を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ A powerful command-line interface tool for managing your Todoist tasks, built wi
 - 🏷️ **Label Support**: Categorize tasks with labels
 - 📅 **Due Date Management**: Set and manage task deadlines
 - 🔄 **Offline Support**: Work offline with local sync
-- 🌍 **Multi-language**: English and Japanese support
 - 🚀 **Fast & Lightweight**: Optimized for speed and efficiency
 
 ## Installation
@@ -134,9 +133,6 @@ gotodoist config init
 # View current config
 gotodoist config show
 
-# Set preferences
-gotodoist config set language ja             # Set language to Japanese
-gotodoist config set language en             # Set language to English
 ```
 
 ## Configuration Options
@@ -148,7 +144,6 @@ Configuration file location:
 ### Environment Variables
 
 - `TODOIST_API_TOKEN`: Your Todoist API token
-- `GOTODOIST_LANG`: Language preference (en/ja)
 
 ## Tips and Examples
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -17,7 +17,6 @@ Goで構築された、Todoistタスクを管理するための強力なコマ�
 - 🏷️ **ラベル対応**: ラベルでタスクを分類
 - 📅 **期限管理**: タスクの期限を設定・管理
 - 🔄 **オフライン対応**: ローカル同期によるオフライン作業
-- 🌍 **多言語対応**: 英語と日本語をサポート
 - 🚀 **高速・軽量**: 速度と効率性を重視した設計
 
 ## インストール
@@ -134,9 +133,6 @@ gotodoist config init
 # 現在の設定を表示
 gotodoist config show
 
-# 設定の変更
-gotodoist config set language ja             # 言語を日本語に設定
-gotodoist config set language en             # 言語を英語に設定
 ```
 
 ## 設定オプション
@@ -148,7 +144,6 @@ gotodoist config set language en             # 言語を英語に設定
 ### 環境変数
 
 - `TODOIST_API_TOKEN`: TodoistのAPIトークン
-- `GOTODOIST_LANG`: 言語設定 (en/ja)
 
 ## 使用例とTips
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -29,7 +29,6 @@ var configCmd = &cobra.Command{
 This command helps you manage your gotodoist configuration including:
 - API token setup
 - Configuration file location
-- Language preferences
 - Current configuration values
 
 Configuration Priority (highest to lowest):
@@ -118,7 +117,6 @@ func showConfig(_ *cobra.Command, _ []string) error {
 	fmt.Println("Current Configuration:")
 	fmt.Printf("  API Token: %s\n", maskToken(cfg.APIToken))
 	fmt.Printf("  Base URL:  %s\n", cfg.BaseURL)
-	fmt.Printf("  Language:  %s\n", cfg.Language)
 
 	configDir, err := config.GetConfigDir()
 	if err == nil {
@@ -131,12 +129,6 @@ func showConfig(_ *cobra.Command, _ []string) error {
 		fmt.Printf("  TODOIST_API_TOKEN: %s\n", maskToken(token))
 	} else {
 		fmt.Println("  TODOIST_API_TOKEN: (not set)")
-	}
-
-	if lang := os.Getenv("GOTODOIST_LANG"); lang != "" {
-		fmt.Printf("  GOTODOIST_LANG: %s\n", lang)
-	} else {
-		fmt.Println("  GOTODOIST_LANG: (not set)")
 	}
 
 	return nil

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -19,11 +19,6 @@ func IsDebug() bool {
 	return globalFlags.Debug
 }
 
-// GetLanguage は設定された言語を返す
-func GetLanguage() string {
-	return globalFlags.Lang
-}
-
 // IsShowBenchmark はベンチマーク表示モードかどうかを返す
 func IsShowBenchmark() bool {
 	return globalFlags.ShowBenchmark

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,6 @@ const (
 type GlobalFlags struct {
 	Verbose       bool
 	Debug         bool
-	Lang          string
 	ShowBenchmark bool
 }
 
@@ -36,7 +35,6 @@ func init() {
 	// グローバルフラグの設定
 	rootCmd.PersistentFlags().BoolVarP(&globalFlags.Verbose, "verbose", "v", false, "enable verbose output")
 	rootCmd.PersistentFlags().BoolVar(&globalFlags.Debug, "debug", false, "enable debug mode")
-	rootCmd.PersistentFlags().StringVar(&globalFlags.Lang, "lang", "", "language preference (en/ja)")
 	rootCmd.PersistentFlags().BoolVar(&globalFlags.ShowBenchmark, "benchmark", false, "show detailed performance timing")
 
 	// 設定の初期化
@@ -83,17 +81,11 @@ func initConfig() {
 		os.Exit(1)
 	}
 
-	// コマンドラインフラグで設定を上書き
-	if globalFlags.Lang != "" {
-		appConfig.Language = globalFlags.Lang
-	}
-
 	// デバッグモードの場合、設定情報を表示
 	if globalFlags.Debug {
 		fmt.Fprintf(os.Stderr, "Configuration loaded:\n")
 		fmt.Fprintf(os.Stderr, "  API Token: %s\n", maskToken(appConfig.APIToken))
 		fmt.Fprintf(os.Stderr, "  Base URL:  %s\n", appConfig.BaseURL)
-		fmt.Fprintf(os.Stderr, "  Language:  %s\n", appConfig.Language)
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -32,12 +32,6 @@ func TestRootCommandFlags(t *testing.T) {
 	if debugFlag != nil {
 		assert.Equal(t, "enable debug mode", debugFlag.Usage, "debugフラグのUsageが期待値と異なります")
 	}
-
-	langFlag := rootCmd.PersistentFlags().Lookup("lang")
-	assert.NotNil(t, langFlag, "langフラグが定義されていません")
-	if langFlag != nil {
-		assert.Equal(t, "language preference (en/ja)", langFlag.Usage, "langフラグのUsageが期待値と異なります")
-	}
 }
 
 func TestRootCommandSubcommands(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	// DefaultLanguage はデフォルト言語設定
-	DefaultLanguage = "en"
 	// ConfigDirPerm は設定ディレクトリのパーミッション
 	ConfigDirPerm = 0750
 	// ConfigFilePerm は設定ファイルのパーミッション
@@ -24,7 +22,6 @@ const (
 type Config struct {
 	APIToken     string             `yaml:"api_token" mapstructure:"api_token"`
 	BaseURL      string             `yaml:"base_url,omitempty" mapstructure:"base_url"`
-	Language     string             `yaml:"language,omitempty" mapstructure:"language"`
 	LocalStorage *repository.Config `yaml:"local_storage,omitempty" mapstructure:"local_storage"`
 }
 
@@ -32,7 +29,6 @@ type Config struct {
 func DefaultConfig() *Config {
 	return &Config{
 		BaseURL:      "https://api.todoist.com/api/v1",
-		Language:     DefaultLanguage,
 		LocalStorage: repository.DefaultConfig(),
 	}
 }
@@ -46,7 +42,6 @@ func LoadConfig() (*Config, error) {
 	defaultConfig := DefaultConfig()
 	v.SetDefault("api_token", defaultConfig.APIToken)
 	v.SetDefault("base_url", defaultConfig.BaseURL)
-	v.SetDefault("language", defaultConfig.Language)
 
 	// ローカルストレージのデフォルト値
 	v.SetDefault("local_storage.enabled", defaultConfig.LocalStorage.Enabled)
@@ -127,9 +122,6 @@ func generateConfigFile(configPath string, defaultConfig *Config) error {
 
 # Todoist API ベースURL（通常は変更不要）
 base_url: "` + defaultConfig.BaseURL + `"
-
-# 言語設定（en/ja）
-language: "` + defaultConfig.Language + `"
 
 # ローカルストレージ設定（高速化機能）
 local_storage:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	expectedBaseURL  = "https://api.todoist.com/api/v1"
-	expectedLanguage = "en"
+	expectedBaseURL = "https://api.todoist.com/api/v1"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -20,7 +19,6 @@ func TestDefaultConfig(t *testing.T) {
 	require.NotNil(t, config, "DefaultConfig()がnilを返しました")
 	assert.Equal(t, expectedBaseURL, config.BaseURL, "BaseURLが期待値と異なります")
 	assert.Empty(t, config.APIToken, "APITokenが空ではありません")
-	assert.Equal(t, expectedLanguage, config.Language, "Languageが期待値と異なります")
 }
 
 func TestLoadConfig(t *testing.T) {
@@ -90,7 +88,6 @@ func TestLoadConfig(t *testing.T) {
 
 			assert.Equal(t, tt.wantToken, config.APIToken, "APITokenが期待値と異なります")
 			assert.Equal(t, expectedBaseURL, config.BaseURL, "BaseURLが期待値と異なります")
-			assert.Equal(t, expectedLanguage, config.Language, "Languageが期待値と異なります")
 
 			// 設定ファイルが自動生成されているかチェック
 			configDir := filepath.Join(tempDir, "gotodoist")
@@ -189,7 +186,6 @@ func TestGenerateConfigFile(t *testing.T) {
 	// 基本的な設定項目が含まれているかチェック
 	expectedContents := []string{
 		"base_url: \"https://api.todoist.com/api/v1\"",
-		"language: \"en\"",
 		"# api_token:",
 	}
 
@@ -235,7 +231,6 @@ func TestLoadConfigFromFile(t *testing.T) {
 	configContent := `# gotodoist CLI設定ファイル
 api_token: "test-file-token"
 base_url: "https://api.todoist.com/api/v1"
-language: "ja"
 `
 	err = os.WriteFile(configPath, []byte(configContent), 0600)
 	require.NoError(t, err, "設定ファイルの書き込みに失敗しました")
@@ -246,6 +241,5 @@ language: "ja"
 
 	// 設定ファイルからの値が正しく読み込まれているかチェック
 	assert.Equal(t, "test-file-token", config.APIToken, "APITokenが期待値と異なります")
-	assert.Equal(t, "ja", config.Language, "Languageが期待値と異なります")
 	assert.Equal(t, "https://api.todoist.com/api/v1", config.BaseURL, "BaseURLが期待値と異なります")
 }

--- a/internal/factory/factory_test.go
+++ b/internal/factory/factory_test.go
@@ -85,7 +85,6 @@ func TestNewRepository(t *testing.T) {
 	cfg := &config.Config{
 		APIToken:     "test-token",
 		BaseURL:      "https://api.todoist.com/api/v1",
-		Language:     "en",
 		LocalStorage: repository.DefaultConfig(),
 	}
 


### PR DESCRIPTION
## Summary
- 使用されていない言語設定機能を削除しました
- コードベースをシンプルにし、メンテナンス性を向上させました

## 削除内容
- `Config`構造体から`Language`フィールドを削除
- `DefaultLanguage`定数を削除
- config.yamlテンプレートから言語設定の項目を削除
- README.md/README_ja.mdから言語設定の記述を削除
- コマンドラインフラグ（`--lang`）を削除
- 環境変数（`GOTODOIST_LANG`）のサポートを削除
- `GetLanguage()`ヘルパー関数を削除
- テストコードから言語設定関連のテストを削除

## Test plan
- [x] `make test` - 全テストがパス
- [x] `make lint` - lint エラーなし
- [x] `make ci` - CI チェックがパス

🤖 Generated with [Claude Code](https://claude.ai/code)